### PR TITLE
Closes #5

### DIFF
--- a/src/rtpytools/common/io.py
+++ b/src/rtpytools/common/io.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+from typing import List
+
+
+def ls(p: Path) -> List[str]:
+    """
+    List all files in the given directory and its subdirectories.
+
+    :param p: The path to the directory.
+    :type p: Path object
+    :return: A list of paths to all the files found.
+    :rtype: List[Path]
+    :raises IOError: If the input directory does not exist.
+    """
+    if not p.exists():
+        raise IOError(f"Input directory does not exist: {p}")
+    lf = []
+    for root, dirs, files in os.walk(p):
+        for file in files:
+            lf.append(os.path.join(root, file))
+    return lf

--- a/src/rtpytools/dcmcp/dcmcp.py
+++ b/src/rtpytools/dcmcp/dcmcp.py
@@ -1,30 +1,11 @@
 import argparse
-import os
 import shutil
 from pathlib import Path
-from typing import List
 
 from pydicom import dcmread
 from pydicom.errors import InvalidDicomError
 
-
-def ls(p: Path) -> List[str]:
-    """
-    List all files in the given directory and its subdirectories.
-
-    :param p: The path to the directory.
-    :type p: Path object
-    :return: A list of paths to all the files found.
-    :rtype: List[Path]
-    :raises IOError: If the input directory does not exist.
-    """
-    if not p.exists():
-        raise IOError(f"Input directory does not exist: {p}")
-    lf = []
-    for root, dirs, files in os.walk(p):
-        for file in files:
-            lf.append(os.path.join(root, file))
-    return lf
+from rtpytools.common.io import ls
 
 
 def dcm_copy_file(src: Path, dest: Path, patient_id: str, verbose: bool = False):


### PR DESCRIPTION
Refactor code by moving 'ls' function to common.io module

The 'ls' function, which lists all files in a directory and its subdirectories, has been moved from dcmcp.py to a new file io.py within the rtpytools/common directory. This change improves modularization and usability of the code across the project.